### PR TITLE
update regex to be more permissive

### DIFF
--- a/inventories/terra-env/hosts
+++ b/inventories/terra-env/hosts
@@ -1,6 +1,6 @@
 [docker-ol2]
-thurloe-[00:99]
+(.+-)*thurloe-[0-9]+
 
 [jenkins-user]
-thurloe-[00:99]
+(.+-)*thurloe-[0-9]+
 


### PR DESCRIPTION
This makes it work with the naming scheme of the profiles (`gmalkov-terra-thurloe-01`)