### PR TITLE
Fixing ansible roles to release tags, adding mongo group

### DIFF
--- a/inventories/terra-env/group_vars/docker-ol2.yml
+++ b/inventories/terra-env/group_vars/docker-ol2.yml
@@ -11,6 +11,5 @@ docker_compose_version: "1.24.0"
 docker_compose_path: /usr/local/bin/docker-compose
 docker-ol2_gitrepos__to_merge:
 #docker
-  - { address: 'https://github.com/broadinstitute/ansible-role-docker.git', name: 'ansible-role-docker', version: 'master' }
-  - { address: 'https://github.com/broadinstitute/ansible-role-local-filesystem.git', name: 'ansible-role-local-filesystem', version: 'master' }
-  - { address: 'https://github.com/broadinstitute/ansible-role-jenkins-user.git', name: 'ansible-role-jenkins-user', version: 'master' }
+  - { address: 'https://github.com/broadinstitute/ansible-role-docker.git', name: 'ansible-role-docker', version: '2.5.2' }
+  - { address: 'https://github.com/broadinstitute/ansible-role-local-filesystem.git', name: 'ansible-role-local-filesystem', version: '1.1.0' }

--- a/inventories/terra-env/group_vars/docker-ol2.yml
+++ b/inventories/terra-env/group_vars/docker-ol2.yml
@@ -1,6 +1,6 @@
 ---
 #overlay2 disk
-filesystems:
+docker-ol2_filesystems__to_merge:
   - { device: '/dev/disk/by-id/google-docker', mountpoint: '/var/lib/docker' }
 #docker vars
 docker_edition: 'ce'

--- a/inventories/terra-env/group_vars/jenkins-user.yml
+++ b/inventories/terra-env/group_vars/jenkins-user.yml
@@ -1,4 +1,4 @@
 ---
 jenkins-user_gitrepos__to_merge:
 #jenkins-user
-  - { address: 'https://github.com/broadinstitute/ansible-role-jenkins-user.git', name: 'ansible-role-jenkins-user', version: 'master' }
+  - { address: 'https://github.com/broadinstitute/ansible-role-jenkins-user.git', name: 'ansible-role-jenkins-user', version: '1.0.0' }

--- a/inventories/terra-env/group_vars/mongo-disk.yml
+++ b/inventories/terra-env/group_vars/mongo-disk.yml
@@ -3,4 +3,4 @@ mongo-disk_filesystems__to_merge:
   - { device: '/dev/disk/by-id/google-data', mountpoint: '/data' }
 
 mongo-disk_gitrepos__to_merge:
-  - { address: 'https://github.com/broadinstitute/ansible-role-local-filesystem.git', name: 'ansible-role-local-filesystem', version: 'hf_merge_var' }
+  - { address: 'https://github.com/broadinstitute/ansible-role-local-filesystem.git', name: 'ansible-role-local-filesystem', version: '1.1.0' }

--- a/inventories/terra-env/group_vars/mongo-disk.yml
+++ b/inventories/terra-env/group_vars/mongo-disk.yml
@@ -1,0 +1,6 @@
+---
+mongo-disk_filesystems__to_merge:
+  - { device: '/dev/disk/by-id/google-data', mountpoint: '/data' }
+
+mongo-disk_gitrepos__to_merge:
+  - { address: 'https://github.com/broadinstitute/ansible-role-local-filesystem.git', name: 'ansible-role-local-filesystem', version: 'hf_merge_var' }

--- a/inventories/terra-env/hosts
+++ b/inventories/terra-env/hosts
@@ -6,3 +6,5 @@ mongo-[00:99]
 thurloe-[00:99]
 mongo-[00:99]
 
+[mongo-disk]
+mongo-[00:99]


### PR DESCRIPTION
- Getting ready for master merge so fixing ansible role git repos to actual release tags
- Added mongo group to add attached disk
- adopted updated local filesystem ansible role that uses merged_var capability